### PR TITLE
Removing networkReady check in StopPodSandbox before calling cni DEL

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -258,8 +258,7 @@ func (ds *dockerService) StopPodSandbox(ctx context.Context, r *runtimeapi.StopP
 	// since it is stopped. With empty network namespace, CNI bridge plugin will conduct best
 	// effort clean up and will not return error.
 	errList := []error{}
-	ready, ok := ds.getNetworkReady(podSandboxID)
-	if !hostNetwork && (ready || !ok) {
+	if !hostNetwork {
 		// Only tear down the pod network if we haven't done so already
 		cID := kubecontainer.BuildContainerID(runtimeName, podSandboxID)
 		err := ds.network.TearDownPod(namespace, name, cID)


### PR DESCRIPTION
Race condition is between RunPodSandbox and StopPodSandbox when setting up network.